### PR TITLE
Stop using distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,11 @@
 import datetime
 import os
 
-from distutils.core import Command
-from distutils.errors import DistutilsOptionError
 from os.path import (
     dirname,
     join as opj,
 )
+from setuptools import Command, DistutilsOptionError
 from setuptools.config import read_configuration
 
 import versioneer


### PR DESCRIPTION
[Distutils was officially deprecated in Python 3.10 and will be removed from the standard library completely in 3.12.](https://www.python.org/dev/peps/pep-0632/)  This PR thus removes the use of distutils from the code.